### PR TITLE
feat: add additionalPorts and ingress custom health check

### DIFF
--- a/charts/monom-react/Chart.yaml
+++ b/charts/monom-react/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/monom-react/templates/ingress.yaml
+++ b/charts/monom-react/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "monom-react.name" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -15,6 +15,9 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: ImplementationSpecific
 {{- end }}

--- a/charts/monom-spring/Chart.yaml
+++ b/charts/monom-spring/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/monom-spring/templates/backendconfig.yaml
+++ b/charts/monom-spring/templates/backendconfig.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.ingress.healthCheck -}}
+{{- $fullName := include "monom-spring.name" . -}}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "monom-spring.labels" . | nindent 4 }}
+spec:
+  healthCheck:
+    {{- toYaml .Values.ingress.healthCheck | nindent 4 }}
+{{- end }}

--- a/charts/monom-spring/templates/deployment.yaml
+++ b/charts/monom-spring/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- if .Values.additionalPorts }}
+            {{- toYaml .Values.additionalPorts | nindent 12 }}
+            {{- end }}
           {{- if .Values.readinessProbe }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}

--- a/charts/monom-spring/templates/ingress.yaml
+++ b/charts/monom-spring/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "monom-spring.name" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -15,6 +15,9 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: ImplementationSpecific
 {{- end }}

--- a/charts/monom-spring/templates/service.yaml
+++ b/charts/monom-spring/templates/service.yaml
@@ -11,5 +11,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.service.additionalPorts }}
+    {{- toYaml .Values.service.additionalPorts | nindent 4 }}
+    {{- end }}
   selector:
     {{- include "monom-spring.selectorLabels" . | nindent 4 }}

--- a/charts/monom-spring/values.yaml
+++ b/charts/monom-spring/values.yaml
@@ -30,13 +30,16 @@ serviceAccountName: ""
 service:
   type: ClusterIP
   port: 80
+  additionalPorts: []
 
 ingress:
   enabled: false
   annotations: {}
   host: ""
+  healthCheck: {}
 
 env: {}
+additionalPorts: []
 
 resources:
   limits:


### PR DESCRIPTION
render with values https://github.com/ThingsO2/gateway/blob/BET-1219/helm-values/values-dev.yaml
```
---
# Source: monom-spring/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME
  labels:
    helm.sh/chart: monom-spring-0.4.3
    app.kubernetes.io/name: RELEASE-NAME
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: RELEASE-NAME-randAlphaNum
spec:
  type: NodePort
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
    - name: health
      port: 8081
      protocol: TCP
      targetPort: health
  selector:
    app.kubernetes.io/name: RELEASE-NAME
---
# Source: monom-spring/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME
  labels:
    helm.sh/chart: monom-spring-0.4.3
    app.kubernetes.io/name: RELEASE-NAME
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: RELEASE-NAME-randAlphaNum
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: RELEASE-NAME
  template:
    metadata:
      labels:
        app.kubernetes.io/name: RELEASE-NAME
    spec:
      securityContext:
        {}
      containers:
        - name: monom-spring
          securityContext:
            {}
          image: ${#triggerResolvedArtifactByType("docker/image")["reference"]}
          imagePullPolicy: IfNotPresent
          env:
            - name: SPRING_PROFILES_ACTIVE
              value: dev
            - name: SPRING_CONFIG_URI
              value: http://spring-config-server:8888
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
            - containerPort: 8081
              name: health
              protocol: TCP
          readinessProbe:
            failureThreshold: 5
            httpGet:
              path: /actuator/health
              port: 8081
              scheme: HTTP
            initialDelaySeconds: 55
            periodSeconds: 25
            successThreshold: 1
            timeoutSeconds: 5
          livenessProbe:
            failureThreshold: 2
            httpGet:
              path: /actuator/health
              port: 8081
              scheme: HTTP
            initialDelaySeconds: 90
            periodSeconds: 25
            successThreshold: 1
            timeoutSeconds: 5
          resources:
            limits:
              cpu: 750m
              memory: 1Gi
            requests:
              cpu: 250m
              memory: 512Mi
          volumeMounts:
            - mountPath: /etc/monom
              name: key-volume
              readOnly: true
      volumes:
        - name: key-volume
          secret:
            items:
            - key: jwt.key
              path: credentials/private.key
            secretName: gateway-credentials-string
---
# Source: monom-spring/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: RELEASE-NAME
  labels:
    helm.sh/chart: monom-spring-0.4.3
    app.kubernetes.io/name: RELEASE-NAME
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: RELEASE-NAME-randAlphaNum
  annotations:
    kubernetes.io/ingress.class: gce
    networking.gke.io/v1beta1.FrontendConfig: RELEASE-NAME-ingress-security-config
    kubernetes.io/ingress.global-static-ip-name: RELEASE-NAME
    networking.gke.io/managed-certificates: RELEASE-NAME
spec:
  rules:
    - host: "api.dev.monom.ai"
      http:
        paths:
          - backend:
              service:
                name: RELEASE-NAME
                port:
                  number: 80
            pathType: ImplementationSpecific
---
# Source: monom-spring/templates/backendconfig.yaml
apiVersion: cloud.google.com/v1
kind: BackendConfig
metadata:
  name: RELEASE-NAME
  labels:
    helm.sh/chart: monom-spring-0.4.3
    app.kubernetes.io/name: RELEASE-NAME
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: RELEASE-NAME-randAlphaNum
spec:
  healthCheck:
    checkIntervalSec: 60
    port: 8081
    requestPath: /actuator/health
    timeoutSec: 30
    type: HTTP
```