### PR TITLE
fix: service when there are several BackendConfig

### DIFF
--- a/charts/monom-spring/Chart.yaml
+++ b/charts/monom-spring/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/monom-spring/templates/service.yaml
+++ b/charts/monom-spring/templates/service.yaml
@@ -1,15 +1,40 @@
-{{- $fullName := include "monom-spring.name" . -}}
-{{- $backendConfigDict := dict .Values.service.port $fullName -}}
+{{- $fullName := include "monom-spring.name" . }}
+{{- $additionalPorts := .Values.service.additionalPorts | default dict }}
+{{- if .Values.ingress.backends }}
+{{- range .Values.ingress.backends }}
+{{- $serviceName := printf "%s-%s" $fullName .suffixName }}
+{{- $backendConfigDict := dict .port $serviceName }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    {{- include "monom-spring.labels" $ | nindent 4 }}
+  annotations:
+    cloud.google.com/backend-config: '{{- dict "ports" $backendConfigDict | toJson }}'
+spec:
+  type: {{ include "monom-spring.service-type" $ }}
+  ports:
+    - port: {{ .port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if $additionalPorts }}
+    {{- toYaml $additionalPorts | nindent 4 }}
+    {{- end }}
+  selector:
+    {{- include "monom-spring.selectorLabels" $ | nindent 4 }}
+...
+{{- end }}
+{{- else }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "monom-spring.name" . }}
   labels:
     {{- include "monom-spring.labels" . | nindent 4 }}
-  {{- if .Values.ingress.healthCheck }}
-  annotations:
-    cloud.google.com/backend-config: '{{- dict "ports" $backendConfigDict | toJson }}'
-  {{- end }}
 spec:
   type: {{ include "monom-spring.service-type" . }}
   ports:
@@ -22,3 +47,4 @@ spec:
     {{- end }}
   selector:
     {{- include "monom-spring.selectorLabels" . | nindent 4 }}
+{{- end}}


### PR DESCRIPTION
```
---
# Source: monom-spring/templates/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: release-name
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
spec:
  maxUnavailable: 50%
  selector:
    matchLabels:
      app.kubernetes.io/name: release-name
---
# Source: monom-spring/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-default
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
  annotations:
    cloud.google.com/backend-config: '{"ports":{"80":"release-name-default"}}'
spec:
  type: NodePort
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
    - name: health
      port: 8081
      protocol: TCP
      targetPort: health
  selector:
    app.kubernetes.io/name: release-name
...
---
# Source: monom-spring/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-sse
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
  annotations:
    cloud.google.com/backend-config: '{"ports":{"80":"release-name-sse"}}'
spec:
  type: NodePort
  ports:
    - port: 80
      targetPort: http
      protocol: TCP
      name: http
    - name: health
      port: 8081
      protocol: TCP
      targetPort: health
  selector:
    app.kubernetes.io/name: release-name
...
---
# Source: monom-spring/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: release-name
    spec:
      securityContext:
        fsGroup: 1000
        runAsUser: 1000
      containers:
        - name: release-name
          securityContext:
            allowPrivilegeEscalation: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            runAsUser: 1000
          image: ${#triggerResolvedArtifactByType("docker/image")["reference"]}
          imagePullPolicy: IfNotPresent
          env:
            - name: SPRING_PROFILES_ACTIVE
              value: dev
            - name: SPRING_CONFIG_URI
              value: http://spring-config-server:8888
          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
            - containerPort: 8081
              name: health
              protocol: TCP
          readinessProbe:
            failureThreshold: 5
            httpGet:
              path: /actuator/health
              port: 8081
              scheme: HTTP
            initialDelaySeconds: 20
            periodSeconds: 25
            successThreshold: 1
            timeoutSeconds: 5
          livenessProbe:
            failureThreshold: 2
            httpGet:
              path: /actuator/health
              port: 8081
              scheme: HTTP
            initialDelaySeconds: 25
            periodSeconds: 25
            successThreshold: 1
            timeoutSeconds: 5
          resources:
            limits:
              cpu: 3
              memory: 600Mi
            requests:
              cpu: 50m
              memory: 350Mi
          volumeMounts:
            - mountPath: /etc/monom
              name: key-volume
              readOnly: true
      volumes:
        - name: key-volume
          secret:
            items:
            - key: jwt.key
              path: credentials/private.key
            secretName: gateway-credentials-string
---
# Source: monom-spring/templates/hpa.yaml
apiVersion: autoscaling/v2beta1
kind: HorizontalPodAutoscaler
metadata:
  name: release-name
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: release-name
  minReplicas: 1
  maxReplicas: 3
  metrics:
    - type: Resource
      resource:
        name: cpu
        targetAverageUtilization: 500
---
# Source: monom-spring/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
  annotations:
    ingress.kubernetes.io/cors-credentials: "true"
    ingress.kubernetes.io/cors-methods: PUT, DELETE, GET, PATCH, POST, OPTIONS
    ingress.kubernetes.io/cors-origins: '*'
    ingress.kubernetes.io/enable-cors: "true"
    kubernetes.io/ingress.class: gce
    networking.gke.io/v1beta1.FrontendConfig: release-name-ingress-security-config
    kubernetes.io/ingress.global-static-ip-name: release-name
    networking.gke.io/managed-certificates: release-name
spec:
  rules:
    - host: "api.dev.monom.ai"
      http:
        paths:
          - path: /*
            pathType: ImplementationSpecific
            backend:
              service:
                name: release-name-default
                port:
                  number: 80
          - path: /v1/sse/*
            pathType: ImplementationSpecific
            backend:
              service:
                name: release-name-sse
                port:
                  number: 80
---
# Source: monom-spring/templates/backendconfig.yaml
apiVersion: cloud.google.com/v1
kind: BackendConfig
metadata:
  name: release-name-default
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
spec:
  healthCheck:
    checkIntervalSec: 60
    port: 8081
    requestPath: /actuator/health
    timeoutSec: 30
    type: HTTP
...
---
# Source: monom-spring/templates/backendconfig.yaml
apiVersion: cloud.google.com/v1
kind: BackendConfig
metadata:
  name: release-name-sse
  labels:
    helm.sh/chart: monom-spring-1.3.1
    app.kubernetes.io/name: release-name
    app.kubernetes.io/version: "1.16.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: data-intake
    app.kubernetes.io/part-of: data-intake
    app.kubernetes.io/instance: release-name-randAlphaNum
spec:
  sessionAffinity:
    affinityType: CLIENT_IP
  timeoutSec: 300
  connectionDraining:
    drainingTimeoutSec: 600
  healthCheck:
    checkIntervalSec: 60
    port: 8081
    requestPath: /actuator/health
    timeoutSec: 30
    type: HTTP
...
```